### PR TITLE
Support rational weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ See [PostCSS] docs for examples for your environment.
 .foo {
   color: mix(#f00, #00f);      /*  #800080  */
   color: mix(#f00, #00f, 25%); /*  #4000BF  */
+  color: mix(#f00, #00f, .25); /*  #4000BF  */
   color: mix(rgba(255, 0, 0, 0.5), #00f); /*  rgba(64, 0, 191, 0.75)  */
 }
 ```

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import Color from 'color';
 import { try as postcssTry } from 'postcss-message-helpers';
 
 const mix = (c1, c2, w='') => {
-  const weight = w.replace('%', '');
+  const weight = w.endsWith('%') ? w.replace('%', '') : w * 100;
   const mixed = Color(c1).mix(Color(c2), weight);
   return mixed.alpha() < 1 ? mixed.rgbaString() : mixed.hexString();
 };

--- a/test.js
+++ b/test.js
@@ -19,9 +19,16 @@ it('mix two hex colors without weight', (done)=> {
   done);
 });
 
-it('mix two hex colors with weight', (done)=> {
+it('mix two hex colors with weight as percentage', (done)=> {
   verify(
     `a { color: mix(#f00, #00f, 25%); }`,
+    `a { color: #4000BF; }`,
+  done);
+});
+
+it('mix two hex colors with weight as rational number', (done)=> {
+  verify(
+    `a { color: mix(#f00, #00f, 0.25); }`,
     `a { color: #4000BF; }`,
   done);
 });


### PR DESCRIPTION
This is a little developer’s performance optimization, because `.25` seems to be bit faster<sup>1</sup> to type than `25%` due to “Shift” key usage.

<sup>1. And convenient?</sup>
